### PR TITLE
Fix build.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("/tools/build_rules/appengine/appengine", "appengine_war")
+load("@bazel_tools//tools/build_rules/appengine:appengine.bzl", "appengine_war")
 
 appengine_war(
     name = "dash",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,42 +13,8 @@
 # limitations under the License.
 
 # WORKSPACE file example to download Java AppEngine dependencies.
-new_http_archive(
-    name = "appengine-java",
-    url = "http://central.maven.org/maven2/com/google/appengine/appengine-java-sdk/1.9.23/appengine-java-sdk-1.9.23.zip",
-    sha256 = "05e667036e9ef4f999b829fc08f8e5395b33a5a3c30afa9919213088db2b2e89",
-    build_file = "appengine.BUILD",
-)
-
-bind(
-    name = "appengine/java/sdk",
-    actual = "@appengine-java//:sdk",
-)
-
-bind(
-    name = "appengine/java/api",
-    actual = "@appengine-java//:api",
-)
-
-bind(
-    name = "appengine/java/jars",
-    actual = "@appengine-java//:jars",
-)
-
-maven_jar(
-    name = "javax-servlet-api",
-    artifact = "javax.servlet:servlet-api:2.5",
-)
-
-bind(
-    name = "javax/servlet/api",
-    actual = "//tools/build_rules/appengine:javax.servlet.api",
-)
-
-maven_jar(
-    name = "commons-lang",
-    artifact = "commons-lang:commons-lang:2.6",
-)
+load('@bazel_tools//tools/build_rules/appengine:appengine.bzl', 'appengine_repositories')
+appengine_repositories()
 
 maven_jar(
     name = "easymock",

--- a/appengine.BUILD
+++ b/appengine.BUILD
@@ -39,5 +39,5 @@ java_library(
     name = "javax.servlet.api",
     neverlink = 1,
     visibility = ["//visibility:public"],
-    exports = ["@javax-servlet-api//jar:jar"],
+    exports = ["@javax_servlet_api//jar:jar"],
 )

--- a/src/main/java/BUILD
+++ b/src/main/java/BUILD
@@ -10,10 +10,10 @@ java_library(
     srcs = glob(["**/*.java"]),
     visibility = ["//src/test/java/com/google/devtools/dash:__pkg__"],
     deps = [
-        "@appengine-java//:api",
+        "@com_google_appengine_java//:api",
         "//external:javax/servlet/api",
         "//src/main/protobuf:proto_dash",
-        "//third_party:apache_velocity",
-        "//third_party:guava",
+        "@bazel_tools//third_party:apache_velocity",
+        "@bazel_tools//third_party:guava",
     ],
 )

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("/tools/build_rules/genproto", "proto_java_library")
+load("@bazel_tools//tools/build_rules:genproto.bzl", "proto_java_library")
 
 proto_java_library(
     name = "proto_dash",

--- a/src/test/java/com/google/devtools/dash/BUILD
+++ b/src/test/java/com/google/devtools/dash/BUILD
@@ -3,7 +3,7 @@ java_library(
     srcs = ["ProtoInputStream.java"],
     deps = [
         "//external:javax/servlet/api",
-        "//third_party:protobuf",
+        "@bazel_tools//third_party:protobuf",
     ],
 )
 
@@ -13,12 +13,12 @@ java_test(
         "DashRequestTest.java",
     ],
     deps = [
-        "@appengine-java//:jars",
+        "@com_google_appengine_java//:jars",
         "@easymock//jar",
         ":util",
         "//src/main/java:servlets",
         "//src/main/protobuf:proto_dash",
-        "//third_party:junit4",
-        "//third_party:truth",
+        "@bazel_tools//third_party:junit4",
+        "@bazel_tools//third_party:truth",
     ],
 )


### PR DESCRIPTION
(I'm creating this pull request as there seems to be no `dash` repo on Gerrit. Or perhaps I just can't find it. Feel free to share the Gerrit instance URL that I can submit this to.)

This commit makes dash compile once again by making the following
changes:

- Replace dashes in external repository names with underscores.
- Use labels when referring to Skylark rules.
- Refer to extenal repositories with names that certain `@bazel_tools`
  rules expect.
- Use `@bazel` repository (representing the Bazel source code) to reach
  `third_party` code.