### PR TITLE
Fix path to @bazel_tools//third_party/protobuf

### DIFF
--- a/src/test/java/com/google/devtools/dash/BUILD
+++ b/src/test/java/com/google/devtools/dash/BUILD
@@ -3,7 +3,7 @@ java_library(
     srcs = ["ProtoInputStream.java"],
     deps = [
         "//external:javax/servlet/api",
-        "@bazel_tools//third_party:protobuf",
+        "@bazel_tools//third_party/protobuf",
     ],
 )
 


### PR DESCRIPTION
As of https://github.com/bazelbuild/bazel/commit/b78bbd5dd53ecaeb8a736b69ecd3f014232da1d4, `@bazel_tools//third_party:protobuf` is now `@bazel_tools//third_party/protobuf`.