### PR TITLE
Fix test name so the new java_test find the main class

### DIFF
--- a/src/test/java/com/google/devtools/dash/BUILD
+++ b/src/test/java/com/google/devtools/dash/BUILD
@@ -8,7 +8,7 @@ java_library(
 )
 
 java_test(
-    name = "dash",
+    name = "DashRequestTest",
     srcs = [
         "DashRequestTest.java",
     ],


### PR DESCRIPTION
The legacy java test feature has been turned off, the main class is now find according to the name of the rules not the srcs.