### PR TITLE
Use https://github.com/bazelbuild/rules_appengine for the appengine repo

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_rules/appengine:appengine.bzl", "appengine_war")
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_war")
 
 appengine_war(
     name = "dash",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 # WORKSPACE file example to download Java AppEngine dependencies.
-load('@bazel_tools//tools/build_rules/appengine:appengine.bzl', 'appengine_repositories')
+
+git_repository(
+    name = "io_bazel_rules_appengine",
+    remote = "https://github.com/bazelbuild/rules_appengine.git",
+    tag = "0.0.2",
+)
+
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_repositories")
 appengine_repositories()
 
 maven_jar(

--- a/src/main/java/BUILD
+++ b/src/main/java/BUILD
@@ -10,10 +10,10 @@ java_library(
     srcs = glob(["**/*.java"]),
     visibility = ["//src/test/java/com/google/devtools/dash:__pkg__"],
     deps = [
-        "@com_google_appengine_java//:api",
-        "//external:javax/servlet/api",
-        "//src/main/protobuf:proto_dash",
         "@bazel_tools//third_party:apache_velocity",
         "@bazel_tools//third_party:guava",
+        "@com_google_appengine_java//:api",
+        "@io_bazel_rules_appengine//appengine:javax.servlet.api",
+        "//src/main/protobuf:proto_dash",
     ],
 )

--- a/src/test/java/com/google/devtools/dash/BUILD
+++ b/src/test/java/com/google/devtools/dash/BUILD
@@ -2,8 +2,8 @@ java_library(
     name = "util",
     srcs = ["ProtoInputStream.java"],
     deps = [
-        "//external:javax/servlet/api",
         "@bazel_tools//third_party/protobuf",
+        "@io_bazel_rules_appengine//appengine:javax.servlet.api",
     ],
 )
 
@@ -13,12 +13,12 @@ java_test(
         "DashRequestTest.java",
     ],
     deps = [
+        "@bazel_tools//third_party:junit4",
+        "@bazel_tools//third_party:truth",
         "@com_google_appengine_java//:jars",
         "@easymock//jar",
         ":util",
         "//src/main/java:servlets",
         "//src/main/protobuf:proto_dash",
-        "@bazel_tools//third_party:junit4",
-        "@bazel_tools//third_party:truth",
     ],
 )


### PR DESCRIPTION
The old location no longer exists at HEAD.