### PR TITLE
Use protobuf from the bazel source instead of from bazel_tools

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ git_repository(
 )
 
 git_repository(
-    name = "bazel_protobuf",
+    name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
     commit = "bbf59ed1",
 )

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_protobuf//tools/build_rules:genproto.bzl", "java_proto_library")
+load("@io_bazel//tools/build_rules:genproto.bzl", "java_proto_library")
 
 java_proto_library(
     name = "proto_dash",

--- a/src/test/java/com/google/devtools/dash/BUILD
+++ b/src/test/java/com/google/devtools/dash/BUILD
@@ -2,7 +2,7 @@ java_library(
     name = "util",
     srcs = ["ProtoInputStream.java"],
     deps = [
-        "@bazel_tools//third_party/protobuf",
+        "@io_bazel//third_party/protobuf",
         "@io_bazel_rules_appengine//appengine:javax.servlet.api",
     ],
 )
@@ -13,8 +13,8 @@ java_test(
         "DashRequestTest.java",
     ],
     deps = [
-        "@bazel_tools//third_party:junit4",
-        "@bazel_tools//third_party:truth",
+        "@io_bazel//third_party:junit4",
+        "@io_bazel//third_party:truth",
         "@com_google_appengine_java//:jars",
         "@easymock//jar",
         ":util",


### PR DESCRIPTION
At the same time, rename @bazel_protobuf to @bazel_io which is
the correct name for the bazel repository.

Fixes #8.