### PR TITLE
Update build files not depend on @bazel_tools//third_party

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,7 @@ git_repository(
 git_repository(
     name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
-    commit = "bbf59ed1",
+    tag = "0.2.3",
 )
 
 load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_repositories")

--- a/src/main/java/BUILD
+++ b/src/main/java/BUILD
@@ -10,9 +10,9 @@ java_library(
     srcs = glob(["**/*.java"]),
     visibility = ["//src/test/java/com/google/devtools/dash:__pkg__"],
     deps = [
-        "@bazel_tools//third_party:apache_velocity",
-        "@bazel_tools//third_party:guava",
         "@com_google_appengine_java//:api",
+        "@io_bazel//third_party:apache_velocity",
+        "@io_bazel//third_party:guava",
         "@io_bazel_rules_appengine//appengine:javax.servlet.api",
         "//src/main/protobuf:proto_dash",
     ],


### PR DESCRIPTION
Also updates the Bazel version being included.

Fixes #15.